### PR TITLE
Disable debug mode for tornado server by default

### DIFF
--- a/.env.full
+++ b/.env.full
@@ -46,6 +46,8 @@ PHOENIX_PROJECT_NAME=
 # =============================================
 FRONTEND_PORT=8848
 FRONTEND_IP=127.0.0.1
+# set to true to enable auto reload for tornado server
+# UTU_WEBUI_AUTOLOAD=true
 
 # =============================================
 # Misc

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -89,4 +89,6 @@ The `WebUIChatbot` class is basically a tornado based WebSocket server, which tr
 
 The frontend (in `utu/ui/frontend`, or installed as `utu_agent_ui` package) is a React application, which visualizes the events, and provides a simple UI for users to interact with the agent.
 
-By default, the `WebUIChatbot` will listen on `127.0.0.1:8848` and the front end will try to connect to `ws://127.0.0.1:8848/ws`.
+You can customize the port and IP of `WebUIChatbot` by setting the `FRONTEND_PORT` and `FRONTEND_IP` environment variables (default: `127.0.0.1:8848`). The default WebSocket URL is `ws://localhost:8848/ws`, and you can find and modify this setting in the right top corner of the frontend page.
+
+For development, you can set `UTU_WEBUI_AUTOLOAD=true` to enable auto reload for tornado server.


### PR DESCRIPTION
possible fix for #65 

- Disable autoload for tornado by default
- Add an environment variable `UTU_WEBUI_AUTOLOAD` (when set to `true`, enable autoload)
- Add `autoload` parameter to `launch` function for `WebUIChatbot` and `WebUIAgents`