### PR TITLE
fix _edit_memory return value type

### DIFF
--- a/utu/tools/memory_toolkit.py
+++ b/utu/tools/memory_toolkit.py
@@ -49,10 +49,10 @@ class SimpleMemoryToolkit(AsyncBaseToolkit):
         count = old_memory.count(old_string)
 
         if count > 1:
-            return {
+            return (
                 f"Warning: Found {count} occurrences of '{old_string}'. "
                 "Please confirm which occurrence to replace or use more specific context."
-            }
+            )
 
         self.full_memory = self.full_memory.replace(old_string, new_string)
         return "Edited memory: 1 occurrence replaced."


### PR DESCRIPTION
Thanks for open-sourcing such a great project!

SimpleMemoryToolkit._edit_memory should return string instead of set.