### PR TITLE
[bugfix][codec] fix chinese garbled text when saving agent prompt yaml

### DIFF
--- a/utu/meta/simple_agent_generator.py
+++ b/utu/meta/simple_agent_generator.py
@@ -143,7 +143,7 @@ class SimpleAgentGenerator:
             toolkits_configs=add_indented_lines(toolkits_configs, 2),
         )
         ofn = self.output_dir / f"{task_recorder.name}.yaml"
-        ofn.write_text(config)
+        ofn.write_text(config, encoding="utf-8")
         return ofn, config
 
     async def step1(self, task_recorder: GeneratorTaskRecorder, user_input: str) -> None:


### PR DESCRIPTION
执行`python scripts/gen_simple_agent.py` 生成智能体介绍的时候如果不指定utf8 那么生成的yaml文件中的中文会是乱码