### PR TITLE
[bugfix] remove pexpect.spawn which is not supported on win11

### DIFF
--- a/utu/tools/bash_toolkit.py
+++ b/utu/tools/bash_toolkit.py
@@ -51,7 +51,7 @@ class BashToolkit(AsyncBaseToolkit):
         self.run_command(self.child, self.custom_prompt, f"cd {workspace_root}")
 
     @staticmethod
-    def start_persistent_shell(timeout: int) -> tuple[pexpect.spawn, str]:
+    def start_persistent_shell(timeout: int):
         # https://github.com/pexpect/pexpect/issues/321
 
         # Start a new Bash shell
@@ -74,7 +74,7 @@ class BashToolkit(AsyncBaseToolkit):
             return child, custom_prompt
 
     @staticmethod
-    def run_command(child: pexpect.spawn, custom_prompt: str, cmd: str) -> str:
+    def run_command(child, custom_prompt: str, cmd: str) -> str:
         # Send the command
         child.sendline(cmd)
         # Wait until we see the prompt again


### PR DESCRIPTION
<img width="1908" height="627" alt="image" src="https://github.com/user-attachments/assets/c0f1b42f-9757-4ecb-afd9-62dcfeaa8a30" />

win11不支持这个pexpect.spawn 之前放在函数体内还好不会被直接访问到，现在放在变量类型上在win上运行会直接报错了