### PR TITLE
[bugfix] ValueError: Environment variable UTU_DB_URL is not set

### DIFF
--- a/utu/utils/env.py
+++ b/utu/utils/env.py
@@ -9,8 +9,11 @@ load_dotenv(find_dotenv(raise_error_if_not_found=True), verbose=True, override=T
 class EnvUtils:
     @staticmethod
     def get_env(key: str, default: str | None = None) -> str | None:
+        """Get the value of an environment variable. Raise an error if default is not privided (None)"""
         if default is None:
             res = os.getenv(key)
+            if res is None:
+                raise ValueError(f"Environment variable {key} is not set")
             return res
         return os.getenv(key, default)
 

--- a/utu/utils/sqlmodel_utils.py
+++ b/utu/utils/sqlmodel_utils.py
@@ -13,7 +13,7 @@ class SQLModelUtils:
     def get_engine(cls):
         if cls._engine is None:
             cls._engine = create_engine(
-                EnvUtils.get_env("UTU_DB_URL"),
+                EnvUtils.get_env("UTU_DB_URL"),  # assert UTU_DB_URL is provided here!
                 pool_size=300,
                 max_overflow=500,
                 pool_timeout=30,
@@ -32,7 +32,7 @@ class SQLModelUtils:
 
     @staticmethod
     def check_db_available():
-        if not EnvUtils.get_env("UTU_DB_URL"):
+        if not EnvUtils.get_env("UTU_DB_URL", ""):
             # logger.error("UTU_DB_URL is not set")
             return False
         try:


### PR DESCRIPTION
```
(youtu-agent) PS D:\fengyongronglu\youtu-agent> python .\pgs\openai_agents\chat_with_me.py
2025-10-10 00:58:30,130[utu.tracing.setup] - WARNING - setup.py:43 - PHOENIX_ENDPOINT or PHOENIX_PROJECT_NAME is not set! Skipping OpenTelemetry tracing.
Traceback (most recent call last):
  File "D:\fengyongronglu\youtu-agent\pgs\openai_agents\chat_with_me.py", line 5, in <module>
    from utu.pgs.openai_agents.utils.load_model import load_model
  File "D:\fengyongronglu\youtu-agent\utu\__init__.py", line 10, in <module>
    setup_tracing()
  File "D:\fengyongronglu\youtu-agent\utu\tracing\setup.py", line 85, in setup_tracing
    setup_db_tracing()
  File "D:\fengyongronglu\youtu-agent\utu\tracing\setup.py", line 75, in setup_db_tracing
    if not SQLModelUtils.check_db_available():
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\fengyongronglu\youtu-agent\utu\utils\sqlmodel_utils.py", line 35, in check_db_available
    if not EnvUtils.get_env("UTU_DB_URL"):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\fengyongronglu\youtu-agent\utu\utils\env.py", line 15, in get_env
    raise ValueError(f"Environment variable {key} is not set")
ValueError: Environment variable UTU_DB_URL is not set
```

warning的判断抛出了异常导致如果不配置DB_URL直接挂了