### PR TITLE
[bugfix] 修复example中FileUtils.save_json的参数顺序

### DIFF
--- a/examples/data_analysis/main.py
+++ b/examples/data_analysis/main.py
@@ -25,7 +25,7 @@ async def main():
     await AgentsUtils.print_stream_events(result.stream_events())
 
     # Extract and print the result
-    FileUtils.save_json(result.trajectories, fn.parent / "trajectories.json")
+    FileUtils.save_json(fn.parent / "trajectories.json", result.trajectories)
     with open(fn.parent / "report.html", "w", encoding="utf-8") as f:
         match = re.search(r"```html(.*?)```", result.final_output, re.DOTALL)
         html_str = match.group(1).strip() if match else result.final_output

--- a/examples/file_manager/main.py
+++ b/examples/file_manager/main.py
@@ -21,7 +21,7 @@ async def main():
         await AgentsUtils.print_stream_events(result.stream_events())
 
         print(f"Final output: {result.final_output}")
-        FileUtils.save_json(result.to_input_list(), pathlib.Path(__file__).parent / "trajectories.json")
+        FileUtils.save_json(pathlib.Path(__file__).parent / "trajectories.json", result.to_input_list())
 
 
 if __name__ == "__main__":

--- a/examples/paper_collector/main.py
+++ b/examples/paper_collector/main.py
@@ -23,7 +23,7 @@ async def main():
     await AgentsUtils.print_stream_events(result.stream_events())
 
     print(f"Run completed with result: {result}")
-    FileUtils.save_json(result.trajectories, data_dir / "trajectories.json")
+    FileUtils.save_json(data_dir / "trajectories.json", result.trajectories)
     with open(data_dir / "final_output.txt", "w", encoding="utf-8") as f:
         f.write(result.final_output)
 


### PR DESCRIPTION

```
Traceback (most recent call last):
  File "/SDB-8T/gpt/youtu-agent/examples/file_manager/main.py", line 28, in <module>
    asyncio.run(main())
    ~~~~~~~~~~~^^^^^^^^
  File "/opt/miniconda3/lib/python3.13/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/opt/miniconda3/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/opt/miniconda3/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/SDB-8T/gpt/youtu-agent/examples/file_manager/main.py", line 24, in main
    FileUtils.save_json(result.to_input_list(), pathlib.Path(__file__).parent / "trajectories.json")
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/SDB-8T/gpt/youtu-agent/utu/utils/path.py", line 129, in save_json
    with file_path.open("w", encoding="utf-8") as f:
         ^^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'open'
```