### PR TITLE
fix: ChainPlanner._parse null-guard + TaskRecorder.input default_factory

### DIFF
--- a/utu/agents/common.py
+++ b/utu/agents/common.py
@@ -92,7 +92,7 @@ class DataClassWithStreamEvents:
 class TaskRecorder(DataClassWithStreamEvents):
     task: str = ""
     trace_id: str = ""
-    input: str | list[TResponseInputItem] = field(default_factory=dict)
+    input: str | list[TResponseInputItem] = field(default_factory=list)
 
     # from RunResultStreaming
     final_output: str = ""

--- a/utu/agents/orchestrator/chain.py
+++ b/utu/agents/orchestrator/chain.py
@@ -82,6 +82,8 @@ class ChainPlanner:
         analysis = match.group(1).strip() if match else ""
 
         match = re.search(r"<plan>\s*\[(.*?)\]\s*</plan>", text, re.DOTALL)
+        if match is None:
+            raise ValueError("Failed to parse plan: <plan>[...]</plan> block not found in LLM output")
         plan_content = match.group(1).strip()
         tasks: list[Task] = []
         task_pattern = r'\{"name":\s*"([^"]+)",\s*"task":\s*"([^"]+)"\s*\}'


### PR DESCRIPTION
## Summary

Fixes #261. Two small defensive-coding fixes in `utu/agents/`:

1. **`ChainPlanner._parse`** (`utu/agents/orchestrator/chain.py`) — guard the `<plan>` regex match so a malformed LLM output surfaces a `ValueError` with a clear message instead of `AttributeError: 'NoneType' object has no attribute 'group'`. The preceding `<analysis>` match on line 82 already uses the same defensive style (`if match else ""`).

2. **`TaskRecorder.input`** (`utu/agents/common.py`) — use `default_factory=list` so the runtime default matches the declared type `str | list[TResponseInputItem]`. Other list-typed fields on the same dataclass (`trajectories`, `raw_run_results`) already use `default_factory=list`; `input` was the outlier with `default_factory=dict`.

## Changes

```diff
 # utu/agents/orchestrator/chain.py
 match = re.search(r"<plan>\s*\[(.*?)\]\s*</plan>", text, re.DOTALL)
+if match is None:
+    raise ValueError("Failed to parse plan: <plan>[...]</plan> block not found in LLM output")
 plan_content = match.group(1).strip()
```

```diff
 # utu/agents/common.py
-input: str | list[TResponseInputItem] = field(default_factory=dict)
+input: str | list[TResponseInputItem] = field(default_factory=list)
```

Net: +3/-1 lines across two files, split into two commits so each fix is easy to bisect or cherry-pick.

## Test plan

- [x] `pre-commit run` (ruff check + ruff format) passes locally
- No new tests added — each fix is a one-line behavioural tightening whose effect is observable by reading the surrounding code; happy to add targeted unit tests if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)