### PR TITLE
fix(ui): accept top-level query requests

### DIFF
--- a/tests/ui/test_user_request.py
+++ b/tests/ui/test_user_request.py
@@ -1,0 +1,20 @@
+import os
+
+os.environ.setdefault("UTU_LLM_TYPE", "openai")
+os.environ.setdefault("UTU_LLM_MODEL", "test-model")
+
+from utu.ui.common import UserQuery, UserRequest
+
+
+def test_user_request_accepts_nested_query_content():
+    request = UserRequest(type="query", content={"query": "hello"})
+
+    assert isinstance(request.content, UserQuery)
+    assert request.content.query == "hello"
+
+
+def test_user_request_accepts_legacy_top_level_query():
+    request = UserRequest(type="query", query="hello")
+
+    assert isinstance(request.content, UserQuery)
+    assert request.content.query == "hello"

--- a/utu/ui/common.py
+++ b/utu/ui/common.py
@@ -1,7 +1,7 @@
-from typing import Literal
+from typing import Any, Literal
 
 import agents as ag
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from utu.agents.orchestra import OrchestraStreamEvent
 from utu.agents.orchestrator import OrchestratorStreamEvent
@@ -174,6 +174,15 @@ class UserAnswer(BaseModel):
 class UserRequest(BaseModel):
     type: Literal["query", "list_agents", "switch_agent", "answer", "gen_agent"]
     content: UserQuery | SwitchAgentRequest | UserAnswer | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_legacy_query(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data.get("type") == "query" and data.get("content") is None:
+            query = data.get("query")
+            if query is not None:
+                data = {**data, "content": {"query": query}}
+        return data
 
 
 async def handle_raw_stream_events(event: ag.RawResponsesStreamEvent) -> Event | None:


### PR DESCRIPTION
## Summary

Fixes Web UI query handling for clients that send the query text at the top level of the request payload.

`UserRequest` previously accepted only the nested form:

```json
{"type": "query", "content": {"query": "..."}}
```

Some clients, including `demo/dummy_client.py`, send:

```json
{"type": "query", "query": "..."}
```

That shape parsed with `content=None`, which later caused `AttributeError: 'NoneType' object has no attribute 'query'` in the WebSocket query worker. This change normalizes that legacy/top-level query form into `content` during request validation while keeping the existing nested form unchanged.

Fixes #223.

## Validation

- `UV_PYTHON=/usr/bin/python3.12 uv run pytest tests/ui/test_user_request.py -q`
- `UV_PYTHON=/usr/bin/python3.12 uv run ruff check utu/ui/common.py tests/ui/test_user_request.py`
- `UV_PYTHON=/usr/bin/python3.12 uv run ruff format --check utu/ui/common.py tests/ui/test_user_request.py`
- `git diff --check`

Additional note: `UV_PYTHON=/usr/bin/python3.12 uv run pytest tests/ui/test_user_request.py tests/utils/test_print_utils.py -q` passes the new UI request tests, but the existing `tests/utils/test_print_utils.py` cases fail in this non-interactive shell because `prompt_toolkit` raises `EOFError` when stdin is not a TTY.
