### PR TITLE
fix(db): Record trajectory time cost

### DIFF
--- a/tests/db/test_trajectory.py
+++ b/tests/db/test_trajectory.py
@@ -9,3 +9,24 @@ async def test_traj_model():
     task_recorder = await agent.run("hello")
     trajectory = TrajectoryModel.from_task_recorder(task_recorder)
     DBService.add(trajectory)
+
+
+def test_trajectory_model_uses_recorder_time_cost():
+    from utu.agents.common import TaskRecorder
+
+    recorder = TaskRecorder(task="hello", input="hello", trace_id="trace-test")
+    recorder.completed_at = recorder.started_at + 2.5
+
+    trajectory = TrajectoryModel.from_task_recorder(recorder)
+
+    assert trajectory.time_cost == 2.5
+
+
+def test_trajectory_model_leaves_unfinished_time_cost_empty():
+    from utu.agents.common import TaskRecorder
+
+    recorder = TaskRecorder(task="hello", input="hello", trace_id="trace-test")
+
+    trajectory = TrajectoryModel.from_task_recorder(recorder)
+
+    assert trajectory.time_cost is None

--- a/utu/agents/common.py
+++ b/utu/agents/common.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 import traceback
 from collections.abc import AsyncIterator
 from dataclasses import asdict, dataclass, field
@@ -93,6 +94,8 @@ class TaskRecorder(DataClassWithStreamEvents):
     task: str = ""
     trace_id: str = ""
     input: str | list[TResponseInputItem] = field(default_factory=dict)
+    started_at: float = field(default_factory=time.perf_counter)
+    completed_at: float | None = None
 
     # from RunResultStreaming
     final_output: str = ""
@@ -104,10 +107,21 @@ class TaskRecorder(DataClassWithStreamEvents):
     # additional infos
     additional_infos: dict = field(default_factory=dict)
 
+    @property
+    def time_cost(self) -> float | None:
+        if self.completed_at is None:
+            return None
+        return self.completed_at - self.started_at
+
+    def mark_completed(self) -> None:
+        if self.completed_at is None:
+            self.completed_at = time.perf_counter()
+
     def to_input_list(self) -> list[TResponseInputItem]:
         return self.get_run_result().to_input_list()
 
     def add_run_result(self, run_result: RunResult, agent_name: str = None):
+        self.mark_completed()
         self.raw_run_results.append(run_result)
         self.trajectories.append(
             AgentsUtils.get_trajectory_from_agent_result(run_result, agent_name or run_result.last_agent.name)

--- a/utu/db/trajectory_model.py
+++ b/utu/db/trajectory_model.py
@@ -29,5 +29,5 @@ class TrajectoryModel(SQLModel, table=True):
             d_input=d_input,
             d_output=task_recorder.final_output,
             trajectories=json.dumps(task_recorder.trajectories, ensure_ascii=False),
-            time_cost=-1,
+            time_cost=task_recorder.time_cost,
         )


### PR DESCRIPTION
## Summary
- add elapsed-time tracking to `TaskRecorder`
- store the recorder's measured `time_cost` in `TrajectoryModel` instead of the hardcoded `-1`
- add regression coverage for finished and unfinished recorders

Closes #201

## Validation
- `UTU_LLM_TYPE=openai UTU_LLM_MODEL=dummy UV_PROJECT_ENVIRONMENT=.venv312 uv run --python python3.12 pytest tests/db/test_trajectory.py -q -k 'trajectory_model_uses_recorder_time_cost or trajectory_model_leaves_unfinished_time_cost_empty'`
- `UTU_LLM_TYPE=openai UTU_LLM_MODEL=dummy UV_PROJECT_ENVIRONMENT=.venv312 uv run --python python3.12 ruff check utu/agents/common.py utu/agents/simple_agent.py utu/db/trajectory_model.py tests/db/test_trajectory.py`