### PR TITLE
fix(tools): Keep IPython available without matplotlib

### DIFF
--- a/tests/tools/test_local_python_executor.py
+++ b/tests/tools/test_local_python_executor.py
@@ -1,0 +1,88 @@
+import builtins
+import importlib
+import sys
+from types import ModuleType
+
+
+def reload_local_python_with_stubbed_ipython_without_matplotlib(monkeypatch):
+    class FakeInteractiveShell:
+        cleared = False
+
+        @classmethod
+        def clear_instance(cls):
+            cls.cleared = True
+
+        @classmethod
+        def instance(cls, config=None):
+            return cls()
+
+        def run_cell(self, code):
+            exec(code, {})
+
+    class FakeConfig:
+        def __init__(self):
+            self.HistoryManager = type("HistoryManager", (), {})()
+
+    ipython_module = ModuleType("IPython")
+    ipython_core_module = ModuleType("IPython.core")
+    ipython_shell_module = ModuleType("IPython.core.interactiveshell")
+    ipython_shell_module.InteractiveShell = FakeInteractiveShell
+    traitlets_module = ModuleType("traitlets")
+    traitlets_config_module = ModuleType("traitlets.config")
+    traitlets_loader_module = ModuleType("traitlets.config.loader")
+    traitlets_loader_module.Config = FakeConfig
+
+    for name, module in {
+        "IPython": ipython_module,
+        "IPython.core": ipython_core_module,
+        "IPython.core.interactiveshell": ipython_shell_module,
+        "traitlets": traitlets_module,
+        "traitlets.config": traitlets_config_module,
+        "traitlets.config.loader": traitlets_loader_module,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    original_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "matplotlib" or name.startswith("matplotlib."):
+            raise ImportError("matplotlib is not installed")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    sys.modules.pop("utu.tools.local_env.python", None)
+    sys.modules.pop("matplotlib", None)
+    sys.modules.pop("matplotlib.pyplot", None)
+    return importlib.import_module("utu.tools.local_env.python")
+
+
+def test_local_python_import_keeps_ipython_when_matplotlib_is_missing(monkeypatch):
+    local_python = reload_local_python_with_stubbed_ipython_without_matplotlib(monkeypatch)
+
+    assert local_python.InteractiveShell is not None
+    assert local_python.Config is not None
+    assert local_python.plt is None
+
+
+def test_execute_python_code_without_matplotlib_when_shell_is_provided(tmp_path, monkeypatch):
+    local_python = reload_local_python_with_stubbed_ipython_without_matplotlib(monkeypatch)
+
+    shell = local_python.create_ipython_shell()
+    result = local_python.execute_python_code_sync("print('ok')", str(tmp_path), shell=shell)
+
+    assert result["success"]
+    assert "ok" in result["message"]
+
+
+def test_create_ipython_shell_reports_missing_ipython(monkeypatch):
+    from utu.tools.local_env import python as local_python
+
+    monkeypatch.setattr(local_python, "InteractiveShell", None)
+    monkeypatch.setattr(local_python, "Config", None)
+
+    try:
+        local_python.create_ipython_shell()
+    except ImportError as exc:
+        assert "IPython is required" in str(exc)
+    else:
+        raise AssertionError("expected missing IPython to raise ImportError")

--- a/utu/tools/local_env/python.py
+++ b/utu/tools/local_env/python.py
@@ -13,14 +13,19 @@ import traceback
 from typing import TYPE_CHECKING
 
 try:
-    import matplotlib
-    import matplotlib.pyplot as plt
     from IPython.core.interactiveshell import InteractiveShell
     from traitlets.config.loader import Config
+except ImportError:
+    InteractiveShell = None
+    Config = None
+
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
 
     matplotlib.use("Agg")
 except ImportError:
-    pass
+    plt = None
 
 if TYPE_CHECKING:
     from IPython.core.history import HistoryManager
@@ -50,6 +55,9 @@ def create_ipython_shell():
     Returns:
         InteractiveShell: A configured IPython shell instance
     """
+    if InteractiveShell is None or Config is None:
+        raise ImportError("IPython is required for local python execution")
+
     InteractiveShell.clear_instance()
 
     config = Config()
@@ -112,6 +120,9 @@ def execute_python_code_sync(code: str, workdir: str, shell=None):
 
         # Create a new IPython shell instance or reuse existing one
         if shell is None:
+            if InteractiveShell is None or Config is None:
+                raise ImportError("IPython is required for local python execution")
+
             InteractiveShell.clear_instance()
 
             config = Config()
@@ -129,7 +140,7 @@ def execute_python_code_sync(code: str, workdir: str, shell=None):
         with contextlib.redirect_stdout(output), contextlib.redirect_stderr(error_output):
             shell.run_cell(code_clean)
 
-            if plt.get_fignums():
+            if plt is not None and plt.get_fignums():
                 img_buffer = io.BytesIO()
                 plt.savefig(img_buffer, format="png")
                 img_base64 = base64.b64encode(img_buffer.getvalue()).decode("utf-8")


### PR DESCRIPTION
## Summary

Fixes #213.

This splits the local Python executor imports so a missing `matplotlib` installation does not hide a valid `IPython` installation. Code execution can still run without plot capture, while plot export remains enabled when `matplotlib` is installed.

The change also reports a clear error if `IPython` itself is unavailable.

## Validation

- `UTU_LLM_TYPE=openai UTU_LLM_MODEL=dummy UV_PYTHON=/usr/bin/python3.12 uv run pytest tests/tools/test_local_python_executor.py -q`
- `UV_PYTHON=/usr/bin/python3.12 uv run ruff check utu/tools/local_env/python.py tests/tools/test_local_python_executor.py tests/tools/test_python_executor_toolkit.py`
- `UV_PYTHON=/usr/bin/python3.12 uv run ruff format --check utu/tools/local_env/python.py tests/tools/test_local_python_executor.py tests/tools/test_python_executor_toolkit.py`
- `git diff --check`
