### PR TITLE
fix(agents): guard missing plan block and correct TaskRecorder default

### DIFF
--- a/tests/agents/test_issue_261.py
+++ b/tests/agents/test_issue_261.py
@@ -1,0 +1,41 @@
+import pytest
+
+from utu.agents.common import TaskRecorder
+from utu.agents.orchestrator.chain import ChainPlanner
+
+
+def test_chain_planner_parse_missing_plan_block_raises_clear_error():
+    """Missing <plan> block should raise AssertionError, not AttributeError."""
+    planner = object.__new__(ChainPlanner)
+    recorder = TaskRecorder()
+    text_without_plan = "<analysis>some analysis</analysis>\nNo plan here"
+
+    with pytest.raises(AssertionError, match="No tasks parsed from plan"):
+        planner._parse(text_without_plan, recorder)
+
+
+def test_chain_planner_parse_valid_plan_block_still_works():
+    """A well-formed plan block should still be parsed correctly."""
+    planner = object.__new__(ChainPlanner)
+    recorder = TaskRecorder()
+    text = (
+        "<analysis>break it down</analysis>\n"
+        '<plan>[{"name": "agent_a", "task": "do a"}, {"name": "agent_b", "task": "do b"}]</plan>'
+    )
+
+    plan = planner._parse(text, recorder)
+
+    assert plan.analysis == "break it down"
+    assert len(plan.tasks) == 2
+    assert plan.tasks[0].agent_name == "agent_a"
+    assert plan.tasks[0].task == "do a"
+    assert plan.tasks[1].agent_name == "agent_b"
+    assert plan.tasks[1].task == "do b"
+
+
+def test_task_recorder_input_default_is_list():
+    """TaskRecorder.input should default to a list, matching its annotation."""
+    recorder = TaskRecorder()
+
+    assert recorder.input == []
+    assert isinstance(recorder.input, list)

--- a/utu/agents/common.py
+++ b/utu/agents/common.py
@@ -92,7 +92,7 @@ class DataClassWithStreamEvents:
 class TaskRecorder(DataClassWithStreamEvents):
     task: str = ""
     trace_id: str = ""
-    input: str | list[TResponseInputItem] = field(default_factory=dict)
+    input: str | list[TResponseInputItem] = field(default_factory=list)
 
     # from RunResultStreaming
     final_output: str = ""

--- a/utu/agents/orchestrator/chain.py
+++ b/utu/agents/orchestrator/chain.py
@@ -82,7 +82,7 @@ class ChainPlanner:
         analysis = match.group(1).strip() if match else ""
 
         match = re.search(r"<plan>\s*\[(.*?)\]\s*</plan>", text, re.DOTALL)
-        plan_content = match.group(1).strip()
+        plan_content = match.group(1).strip() if match else ""
         tasks: list[Task] = []
         task_pattern = r'\{"name":\s*"([^"]+)",\s*"task":\s*"([^"]+)"\s*\}'
         task_matches = re.findall(task_pattern, plan_content, re.IGNORECASE)


### PR DESCRIPTION
## Summary

Fixes #261.

This PR addresses two small defensive-coding issues in `utu/agents/`.

## Changes

### 1. `ChainPlanner._parse` no longer crashes on a missing `<plan>` block

**File:** `utu/agents/orchestrator/chain.py`

The `<analysis>` match was already guarded with `if match else ""`, but the `<plan>` match immediately called `.group(1)` without checking for `None`. When the LLM returns malformed/truncated output that omits the plan block, this raised:

```
AttributeError: 'NoneType' object has no attribute 'group'
```

Now the plan match is guarded the same way as the analysis match. The existing `assert len(tasks) > 0, "No tasks parsed from plan"` still produces a clear error for the empty-plan case.

### 2. `TaskRecorder.input` default matches its annotation

**File:** `utu/agents/common.py`

`TaskRecorder.input` is annotated as `str | list[TResponseInputItem]`, but its `default_factory` was `dict`, so a default instance got `input = {}`. This change aligns it with the other list-typed fields on the same dataclass by using `default_factory=list`.

## Tests

Added `tests/agents/test_issue_261.py` covering:

- Missing `<plan>` block raises `AssertionError` (not `AttributeError`).
- Valid plan block is still parsed correctly.
- `TaskRecorder()` defaults `input` to an empty list.

All three tests pass.
