### PR TITLE
fix: support local bash on Windows

### DIFF
--- a/tests/tools/test_bash_pexpect_windows.py
+++ b/tests/tools/test_bash_pexpect_windows.py
@@ -1,0 +1,18 @@
+from unittest.mock import Mock
+
+from utu.tools.local_env.bash_pexpect import PexpectBash
+
+
+def test_start_persistent_shell_uses_popen_spawn_on_windows(monkeypatch):
+    child = Mock()
+    spawn = Mock(return_value=child)
+    monkeypatch.setattr("utu.tools.local_env.bash_pexpect.sys.platform", "win32")
+    monkeypatch.setattr(PexpectBash, "_spawn_windows_shell", spawn)
+
+    result, prompt = PexpectBash.start_persistent_shell(timeout=12)
+
+    spawn.assert_called_once_with(12)
+    child.sendline.assert_called_once_with("prompt PROMPT_$G")
+    child.expect.assert_called_once_with("PROMPT_>")
+    assert result is child
+    assert prompt == "PROMPT_>"

--- a/utu/tools/local_env/bash_pexpect.py
+++ b/utu/tools/local_env/bash_pexpect.py
@@ -25,14 +25,21 @@ class PexpectBash:
         ]
 
     @staticmethod
+    def _spawn_windows_shell(timeout: int):
+        """Start cmd.exe through pexpect's cross-platform subprocess backend."""
+        from pexpect.popen_spawn import PopenSpawn
+
+        return PopenSpawn("cmd.exe /Q", encoding="utf-8", timeout=timeout)
+
+    @staticmethod
     def start_persistent_shell(timeout: int):
         # https://github.com/pexpect/pexpect/issues/321
 
         # Start a new Bash shell
         if sys.platform == "win32":
-            child = pexpect.spawn("cmd.exe", encoding="utf-8", echo=False, timeout=timeout)
+            child = PexpectBash._spawn_windows_shell(timeout)
             custom_prompt = "PROMPT_>"
-            child.sendline(f"prompt {custom_prompt}")
+            child.sendline("prompt PROMPT_$G")
             child.expect(custom_prompt)
         else:
             child = pexpect.spawn("/bin/bash", encoding="utf-8", echo=False, timeout=timeout)
@@ -45,7 +52,7 @@ class PexpectBash:
             child.sendline(f"PS1='{custom_prompt}'")
             # Force an initial read until the newly set prompt shows up
             child.expect(custom_prompt)
-            return child, custom_prompt
+        return child, custom_prompt
 
     @staticmethod
     def run_command(child, custom_prompt: str, cmd: str) -> str:


### PR DESCRIPTION
## Summary

- use pexpect's cross-platform `PopenSpawn` backend for `cmd.exe` on Windows
- disable command echo and return the initialized Windows shell just like the Unix branch
- add a regression test for Windows shell selection and prompt setup

Closes #25.

## Why

`pexpect.spawn` is unavailable on Windows, so constructing the local Bash toolkit raised `AttributeError`. The Windows branch also fell through without returning the child process and prompt.

## Validation

- `.venv/Scripts/pytest.exe -q tests/tools/test_bash_pexpect_windows.py`
- `.venv/Scripts/ruff.exe check utu/tools/local_env/bash_pexpect.py tests/tools/test_bash_pexpect_windows.py`
- `.venv/Scripts/ruff.exe format --check utu/tools/local_env/bash_pexpect.py tests/tools/test_bash_pexpect_windows.py`
- Windows smoke test: `PexpectBash(timeout=5).run("echo hello")`
