### PR TITLE
fix: load GAIA from Parquet dataset

### DIFF
--- a/docs/howto/eval.md
+++ b/docs/howto/eval.md
@@ -274,6 +274,24 @@ python scripts/run_eval.py \
   --concurrency 5
 ```
 
+For GAIA, first accept the access conditions on the
+[official dataset page](https://huggingface.co/datasets/gaia-benchmark/GAIA), set `HF_TOKEN`, and then run:
+
+```bash
+# Download the current Parquet-backed dataset and import the validation split
+python scripts/data/process_gaia.py
+
+# Run evaluation on the full official validation split
+python scripts/run_eval.py \
+  --config_name gaia \
+  --exp_id my_gaia_run \
+  --dataset GAIA_validation \
+  --concurrency 5
+```
+
+The 72.8% result reported in the README uses the linked text-only validation subset. The command above imports the
+full official validation split, including rows with attachments.
+
 See the [Evaluation Documentation](https://tencentcloudadp.github.io/youtu-agent/eval) for more details on benchmarks.
 
 ### Configuring Judge Models

--- a/scripts/data/process_gaia.py
+++ b/scripts/data/process_gaia.py
@@ -1,4 +1,5 @@
 import json
+import pathlib
 
 import datasets
 from huggingface_hub import login, snapshot_download
@@ -7,11 +8,30 @@ from sqlmodel import Session, select
 from utu.db.eval_datapoint import DatasetSample
 from utu.utils import DIR_ROOT, EnvUtils, SQLModelUtils
 
-login(EnvUtils.get_env("HF_TOKEN"))
-engine = SQLModelUtils.get_engine()
+GAIA_REPO_ID = "gaia-benchmark/GAIA"
+GAIA_CONFIG_NAME = "2023_all"
 
 
-def build_dataset(split: str) -> datasets.Dataset:
+def download_gaia_snapshot(data_dir: pathlib.Path) -> str:
+    """Download GAIA metadata and attachments in the current Parquet-backed format."""
+    return snapshot_download(
+        repo_id=GAIA_REPO_ID,
+        repo_type="dataset",
+        local_dir=str(data_dir),
+        # README.md contains the dataset configuration used by load_dataset.
+        ignore_patterns=[".gitattributes"],
+    )
+
+
+def load_gaia_dataset(data_dir: pathlib.Path, split: str) -> datasets.Dataset:
+    """Load a GAIA split from the downloaded directory."""
+    return datasets.load_dataset(str(data_dir), GAIA_CONFIG_NAME, split=split)
+
+
+def build_dataset(split: str, engine=None) -> None:
+    if engine is None:
+        engine = SQLModelUtils.get_engine()
+
     dataset_id = f"GAIA_{split}"
     data_dir = DIR_ROOT / "data" / "gaia"
 
@@ -22,20 +42,8 @@ def build_dataset(split: str) -> datasets.Dataset:
             print("Dataset already exists! Skip.")
             return
 
-    if not data_dir.exists():
-        snapshot_download(
-            repo_id="gaia-benchmark/GAIA",
-            repo_type="dataset",
-            local_dir=str(data_dir),
-            ignore_patterns=[".gitattributes", "README.md"],
-        )
-
-    ds = datasets.load_dataset(
-        str(data_dir / "GAIA.py"),
-        name="2023_all",
-        split=split,
-        trust_remote_code=True,
-    )
+    download_gaia_snapshot(data_dir)
+    ds = load_gaia_dataset(data_dir, split)
 
     data: list[DatasetSample] = []
     for i, row in enumerate(ds.to_list()):
@@ -62,4 +70,10 @@ def build_dataset(split: str) -> datasets.Dataset:
         print("Upload complete.")
 
 
-build_dataset(split="validation")
+def main() -> None:
+    login(EnvUtils.get_env("HF_TOKEN"))
+    build_dataset(split="validation")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_process_gaia.py
+++ b/tests/scripts/test_process_gaia.py
@@ -1,0 +1,29 @@
+from unittest.mock import Mock
+
+from scripts.data import process_gaia
+
+
+def test_download_gaia_snapshot_keeps_dataset_card(monkeypatch, tmp_path):
+    snapshot_download = Mock(return_value=str(tmp_path))
+    monkeypatch.setattr(process_gaia, "snapshot_download", snapshot_download)
+
+    result = process_gaia.download_gaia_snapshot(tmp_path)
+
+    assert result == str(tmp_path)
+    snapshot_download.assert_called_once_with(
+        repo_id="gaia-benchmark/GAIA",
+        repo_type="dataset",
+        local_dir=str(tmp_path),
+        ignore_patterns=[".gitattributes"],
+    )
+
+
+def test_load_gaia_dataset_uses_parquet_directory_config(monkeypatch, tmp_path):
+    dataset = object()
+    load_dataset = Mock(return_value=dataset)
+    monkeypatch.setattr(process_gaia.datasets, "load_dataset", load_dataset)
+
+    result = process_gaia.load_gaia_dataset(tmp_path, "validation")
+
+    assert result is dataset
+    load_dataset.assert_called_once_with(str(tmp_path), "2023_all", split="validation")


### PR DESCRIPTION
## Summary

- load the current GAIA Parquet snapshot through its dataset configuration instead of the removed `GAIA.py` loader
- keep the dataset README so Hugging Face can discover the available configurations
- make the import script safe to import and straightforward to unit test
- document GAIA access, import, and evaluation commands

## Why

The upstream GAIA dataset migrated to Parquet and no longer ships `GAIA.py`. The existing importer therefore fails before any examples are processed.

Closes #245

## Validation

- `ruff check scripts/data/process_gaia.py tests/scripts/test_process_gaia.py`
- `ruff format --check scripts/data/process_gaia.py tests/scripts/test_process_gaia.py`
- `pytest -p no:cacheprovider tests/scripts/test_process_gaia.py -q`
- `mkdocs build --strict`
