### PR TITLE
fix: avoid blocking Docker readiness checks

### DIFF
--- a/tests/env/test_docker_manager_async.py
+++ b/tests/env/test_docker_manager_async.py
@@ -1,0 +1,83 @@
+import asyncio
+import threading
+
+import pytest
+
+from utu.env.utils import docker_manager
+from utu.env.utils.docker_manager import DockerManager
+
+
+class FakeResponse:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+
+class FakeContainer:
+    id = "container-id-123456"
+
+
+class FakeContainers:
+    def run(self, *args, **kwargs):
+        return FakeContainer()
+
+
+class FakeClient:
+    containers = FakeContainers()
+
+
+class FakePortManager:
+    def allocate_port(self) -> int:
+        return 9002
+
+    def get_host_ip(self) -> str:
+        return "127.0.0.1"
+
+
+@pytest.mark.asyncio
+async def test_start_container_readiness_check_does_not_block_event_loop(monkeypatch):
+    manager = DockerManager.__new__(DockerManager)
+    manager.image_name = "test:latest"
+    manager.num_preload = 0
+    manager.num_max = -1
+    manager.client = FakeClient()
+    manager.port_manager = FakePortManager()
+    manager.containers = {}
+    manager.lock = asyncio.Lock()
+
+    probe_started = threading.Event()
+    allow_probe_to_finish = threading.Event()
+    probe_observed_event_loop_progress = []
+    probe_count = 0
+
+    def get(_url, timeout):
+        nonlocal probe_count
+        assert timeout == 2
+        probe_count += 1
+        if probe_count == 1:
+            probe_started.set()
+            probe_observed_event_loop_progress.append(allow_probe_to_finish.wait(timeout=1))
+            return FakeResponse(503)
+        return FakeResponse(200)
+
+    original_sleep = asyncio.sleep
+    retry_delays = []
+
+    async def sleep(delay):
+        retry_delays.append(delay)
+        await original_sleep(0)
+
+    async def mark_event_loop_progress():
+        while not probe_started.is_set():
+            await original_sleep(0)
+        allow_probe_to_finish.set()
+
+    monkeypatch.setattr(docker_manager.requests, "get", get)
+    monkeypatch.setattr(docker_manager.asyncio, "sleep", sleep)
+
+    progress_task = asyncio.create_task(mark_event_loop_progress())
+    result = await manager.start_container("test")
+    await progress_task
+
+    assert result["success"] is True
+    assert probe_observed_event_loop_progress == [True]
+    assert retry_delays == [1]

--- a/utu/env/utils/docker_manager.py
+++ b/utu/env/utils/docker_manager.py
@@ -1,7 +1,6 @@
 # ruff: noqa: I001
 import asyncio
 import logging
-import time
 from dataclasses import dataclass
 from enum import Enum
 
@@ -135,7 +134,7 @@ class DockerManager:
 
                 for _ in range(max_retries):
                     try:
-                        response = requests.get(ping_url, timeout=2)
+                        response = await asyncio.to_thread(requests.get, ping_url, timeout=2)
                         if response.status_code == 200:
                             service_ready = True
                             logger.info(f"容器 {id} 服务已就绪，/ping 返回 200")
@@ -144,7 +143,7 @@ class DockerManager:
                     except RequestException as e:
                         logger.debug(f"容器 {id} 服务未就绪，连接异常: {e}，重试中...")
 
-                    time.sleep(retry_interval)
+                    await asyncio.sleep(retry_interval)
 
                 if service_ready:
                     container_info.status = ContainerStatus.RUNNING


### PR DESCRIPTION
## Summary

- move the blocking readiness HTTP request off the asyncio event-loop thread
- replace the blocking retry delay with `asyncio.sleep`
- add a Docker-free async regression test that verifies the event loop progresses during a probe

## Why

`DockerManager.start_container()` could block every coroutine on its event loop for each two-second HTTP probe and one-second retry delay while a container was starting.

Closes #274

## Validation

- `ruff check utu/env/utils/docker_manager.py tests/env/test_docker_manager_async.py`
- `ruff format --check utu/env/utils/docker_manager.py tests/env/test_docker_manager_async.py`
- `pytest -p no:cacheprovider tests/env/test_docker_manager_async.py -q`
