### PR TITLE
fix(webui): prevent agent HTML/CSS from polluting the main UI

### DIFF
--- a/frontend/webui/src/components/MessageComponent.tsx
+++ b/frontend/webui/src/components/MessageComponent.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import DOMPurify from 'dompurify';
 import SafeMarkdown from './SafeMarkdown';
 import type { Message, ToolCallMessage } from '../types/message';
 import type { PlanItem } from '../types/events';
@@ -227,7 +228,15 @@ const MessageComponent: React.FC<MessageComponentProps> = ({
 
     if (contentType === "svg") {
       return (
-        <div className="report-svg" dangerouslySetInnerHTML={{ __html: processedContent }} />
+        <div
+          className="report-svg"
+          dangerouslySetInnerHTML={{
+            __html: DOMPurify.sanitize(processedContent, {
+              FORBID_TAGS: ['style', 'link', 'script'],
+              FORBID_ATTR: ['style'],
+            }),
+          }}
+        />
       );
     }
 

--- a/frontend/webui/src/components/SafeMarkdown.tsx
+++ b/frontend/webui/src/components/SafeMarkdown.tsx
@@ -61,10 +61,14 @@ const SafeMarkdown: React.FC<{ children: React.ReactNode, messageId: String }> =
     return content.replace(/```/g, '');
   };
 
-  // Convert children to string and decode Unicode escapes
+  // Convert children to string and decode Unicode escapes.
+  // Strip stylesheet payloads so agent-generated HTML cannot restyle the app shell
+  // (full HTML reports are isolated via iframe in MessageComponent).
   const content = useMemo(() => {
     const str = typeof children === 'string' ? children : String(children);
-    return decodeUnicodeEscapes(str);
+    return decodeUnicodeEscapes(str)
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, '')
+      .replace(/<link\b[^>]*\brel\s*=\s*["']?stylesheet["']?[^>]*>/gi, '');
   }, [children]);
 
   useEffect(() => {
@@ -133,6 +137,17 @@ const SafeMarkdown: React.FC<{ children: React.ReactNode, messageId: String }> =
       h1: ({node, ...props}) => <h1 className="markdown-h1" {...props} />,
       h2: ({node, ...props}) => <h2 className="markdown-h2" {...props} />,
       h3: ({node, ...props}) => <h3 className="markdown-h3" {...props} />,
+      // Agent-generated HTML often includes <style>/<link rel="stylesheet">.
+      // With rehypeRaw these would inject into the app document and pollute the UI.
+      // Drop them here; full HTML reports are rendered in a sandboxed iframe instead.
+      style: () => null,
+      link: ({ rel, ...props }) => {
+        const relValue = typeof rel === 'string' ? rel.toLowerCase() : '';
+        if (relValue.split(/\s+/).includes('stylesheet')) {
+          return null;
+        }
+        return <link rel={rel} {...props} />;
+      },
     };
 
     // const DebouncedMermaid = memo(({ chart, mermaidId }: { chart: string, mermaidId: string }) => {


### PR DESCRIPTION
## Summary
- Stop agent-generated `<style>` / stylesheet `<link>` from being injected into the app document via `SafeMarkdown` (`rehypeRaw`).
- Sanitize SVG report HTML with DOMPurify (forbid `style`/`link`/`script`).
- Full HTML reports already render in a sandboxed iframe; this closes the markdown/raw-HTML path that was leaking CSS into the shell.

Fixes #242

## Testing plan
- [ ] Render a normal markdown assistant message (unchanged).
- [ ] Stream/generate HTML containing `<style>body{display:none}</style>` in a chat message and confirm the main UI is not restyled.
- [ ] Open an HTML `report` message and confirm iframe preview still works.
- [ ] Open an SVG report and confirm it still renders without injecting page-level CSS.