### PR TITLE
fix(orchestrator): preserve direct router output

### DIFF
--- a/tests/agents/test_orchestrator_chain.py
+++ b/tests/agents/test_orchestrator_chain.py
@@ -1,0 +1,97 @@
+from os import environ
+from unittest.mock import AsyncMock
+
+environ.setdefault("UTU_LLM_TYPE", "openai")
+environ.setdefault("UTU_LLM_MODEL", "test-model")
+
+from utu.agents.orchestrator.chain import ChainPlanner
+from utu.agents.orchestrator.common import Plan, Recorder, Task
+
+
+class FakeRouterResult:
+    def __init__(self, final_output: str, history: list, event: object):
+        self.final_output = final_output
+        self._history = history
+        self._event = event
+
+    async def stream_events(self):
+        yield self._event
+
+    def to_input_list(self) -> list:
+        return self._history
+
+
+class FakeRouter:
+    def __init__(self, result: FakeRouterResult):
+        self.result = result
+        self.inputs = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def run_streamed(self, input):
+        self.inputs.append(input)
+        return self.result
+
+
+def make_planner(router: FakeRouter, create_plan: AsyncMock) -> ChainPlanner:
+    planner = ChainPlanner.__new__(ChainPlanner)
+    planner.router = router
+    planner.create_plan = create_plan
+    return planner
+
+
+async def test_handle_input_records_direct_router_answer_without_creating_plan(monkeypatch):
+    router_event = object()
+    response_history = [{"role": "assistant", "content": "Direct answer"}]
+    result = FakeRouterResult("Direct answer", response_history, router_event)
+    router = FakeRouter(result)
+    create_plan = AsyncMock()
+    planner = make_planner(router, create_plan)
+    recorder = Recorder(input="What is the answer?", history_messages=[{"role": "user", "content": "Earlier question"}])
+    monkeypatch.setattr(
+        "utu.agents.orchestrator.chain.AgentsUtils.get_trajectory_from_agent_result",
+        lambda agent_result, agent_name: {"agent": agent_name, "output": agent_result.final_output},
+    )
+
+    plan = await planner.handle_input(recorder)
+
+    assert plan is None
+    assert recorder.final_output == "Direct answer"
+    assert router.inputs == [
+        [
+            {"role": "user", "content": "Earlier question"},
+            {"role": "user", "content": "What is the answer?"},
+        ]
+    ]
+    assert recorder.history_messages == response_history
+    assert recorder.trajectories == [{"agent": "router", "output": "Direct answer"}]
+    assert recorder._event_queue.get_nowait() is router_event
+    create_plan.assert_not_awaited()
+
+
+async def test_handle_input_creates_plan_when_router_requests_planning(monkeypatch):
+    router_event = object()
+    response_history = [{"role": "assistant", "content": "I will plan first <plan>"}]
+    result = FakeRouterResult("I will plan first <plan>", response_history, router_event)
+    router = FakeRouter(result)
+    expected_plan = Plan(input="Complete this task", tasks=[Task(agent_name="worker", task="Do work")])
+    create_plan = AsyncMock(return_value=expected_plan)
+    planner = make_planner(router, create_plan)
+    recorder = Recorder(input="Complete this task")
+    monkeypatch.setattr(
+        "utu.agents.orchestrator.chain.AgentsUtils.get_trajectory_from_agent_result",
+        lambda agent_result, agent_name: {"agent": agent_name, "output": agent_result.final_output},
+    )
+
+    plan = await planner.handle_input(recorder)
+
+    assert plan is expected_plan
+    assert recorder.final_output is None
+    assert recorder.history_messages == response_history
+    assert recorder.trajectories == [{"agent": "router", "output": "I will plan first <plan>"}]
+    assert recorder._event_queue.get_nowait() is router_event
+    create_plan.assert_awaited_once_with(recorder)

--- a/utu/agents/orchestrator/chain.py
+++ b/utu/agents/orchestrator/chain.py
@@ -38,6 +38,7 @@ class ChainPlanner:
         need_plan = res.final_output.strip().endswith("<plan>")  # special token!
         if need_plan:
             return await self.create_plan(recorder)
+        recorder.final_output = res.final_output
 
     async def create_plan(self, recorder: Recorder) -> Plan:
         """Plan tasks based on the overall task and available agents."""


### PR DESCRIPTION
## Summary

- preserve successful direct router responses as the recorder final output when no plan is requested
- keep the existing plan-triggering path, streamed events, history, and trajectory behavior unchanged
- add focused async coverage for both direct-answer and plan branches

Refs #213

## Why

The router can answer directly without the `<plan>` marker. That run currently completes with `Recorder.final_output` still unset, so downstream consumers such as the data-analysis example receive `None` even though the router produced a successful answer.

## Testing

- `UTU_LLM_TYPE=openai UTU_LLM_MODEL=test-model .venv312/bin/pytest -q tests/agents/test_common.py tests/agents/test_orchestrator_chain.py`
- `.venv312/bin/ruff check utu/agents/orchestrator/chain.py tests/agents/test_orchestrator_chain.py`
- `.venv312/bin/ruff format --check utu/agents/orchestrator/chain.py tests/agents/test_orchestrator_chain.py`
- `git diff --check`
