### PR TITLE
fix(examples): support unstructured research outputs

### DIFF
--- a/examples/research/main.py
+++ b/examples/research/main.py
@@ -4,9 +4,15 @@ import asyncio
 import pathlib
 
 from agents import custom_span, gen_trace_id, trace
-from pydantic import BaseModel
 from rich.console import Console
 
+from examples.research.plan_parser import (
+    ReportData,
+    WebSearchItem,
+    WebSearchPlan,
+    parse_report_data,
+    parse_search_plan,
+)
 from examples.research.printer import Printer
 from utu.agents import SimpleAgent
 from utu.config import ConfigLoader
@@ -14,30 +20,6 @@ from utu.tools import SearchToolkit
 from utu.utils import FileUtils
 
 PROMPTS = FileUtils.load_yaml(pathlib.Path(__file__).parent / "prompts.yaml")
-
-
-class WebSearchItem(BaseModel):
-    reason: str
-    "Your reasoning for why this search is important to the query."
-
-    query: str
-    "The search term to use for the web search."
-
-
-class WebSearchPlan(BaseModel):
-    searches: list[WebSearchItem]
-    """A list of web searches to perform to best answer the query."""
-
-
-class ReportData(BaseModel):
-    short_summary: str
-    """A short 2-3 sentence summary of the findings."""
-
-    markdown_report: str
-    """The final report"""
-
-    follow_up_questions: list[str]
-    """Suggested topics to research further"""
 
 
 class ResearchManager:
@@ -50,7 +32,6 @@ class ResearchManager:
             name="PlannerAgent",
             instructions=PROMPTS["PLANNER_PROMPT"],
             # model="gpt-4o",
-            output_type=WebSearchPlan,
         )
         toolkit = SearchToolkit(ConfigLoader.load_toolkit_config("search"))
         self.search_agent = SimpleAgent(
@@ -62,7 +43,6 @@ class ResearchManager:
             name="WriterAgent",
             instructions=PROMPTS["WRITER_PROMPT"],
             # model="o3-mini",
-            output_type=ReportData,
         )
 
     async def run(self, query: str) -> None:
@@ -101,12 +81,13 @@ class ResearchManager:
         result = await self.planner_agent.run(
             f"Query: {query}",
         )
+        search_plan = parse_search_plan(str(result.final_output))
         self.printer.update_item(
             "planning",
-            f"Will perform {len(result.get_run_result().final_output.searches)} searches",
+            f"Will perform {len(search_plan.searches)} searches",
             is_done=True,
         )
-        return result.get_run_result().final_output_as(WebSearchPlan)
+        return search_plan
 
     async def _perform_searches(self, search_plan: WebSearchPlan) -> list[str]:
         with custom_span("Search the web"):
@@ -141,7 +122,7 @@ class ResearchManager:
             input,
         )
         self.printer.mark_item_done("writing")
-        return result.get_run_result().final_output_as(ReportData)
+        return parse_report_data(str(result.final_output))
 
 
 async def main(query: str) -> None:

--- a/examples/research/plan_parser.py
+++ b/examples/research/plan_parser.py
@@ -1,0 +1,120 @@
+import json
+import re
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class WebSearchItem(BaseModel):
+    reason: str
+    "Your reasoning for why this search is important to the query."
+
+    query: str
+    "The search term to use for the web search."
+
+
+class WebSearchPlan(BaseModel):
+    searches: list[WebSearchItem]
+    """A list of web searches to perform to best answer the query."""
+
+
+class ReportData(BaseModel):
+    short_summary: str
+    """A short 2-3 sentence summary of the findings."""
+
+    markdown_report: str
+    """The final report."""
+
+    follow_up_questions: list[str]
+    """Suggested topics to research further."""
+
+
+def _plan_from_data(data: Any) -> WebSearchPlan | None:
+    """Normalize common JSON plan shapes emitted by different model providers."""
+    searches = data.get("searches") if isinstance(data, dict) else data
+    if not isinstance(searches, list):
+        return None
+
+    normalized: list[WebSearchItem] = []
+    for item in searches[:20]:
+        if isinstance(item, str):
+            query = item.strip()
+            reason = f"Find information relevant to {query}"
+        elif isinstance(item, dict):
+            query = str(item.get("query", "")).strip()
+            reason = str(item.get("reason", "")).strip() or f"Find information relevant to {query}"
+        else:
+            continue
+
+        if query:
+            normalized.append(WebSearchItem(query=query, reason=reason))
+
+    return WebSearchPlan(searches=normalized) if normalized else None
+
+
+def parse_search_plan(output: str) -> WebSearchPlan:
+    """Parse JSON or a markdown/numbered search list into a validated plan."""
+    text = output.strip()
+    json_candidates = [text]
+    json_candidates.extend(re.findall(r"```(?:json)?\s*([\s\S]*?)```", text, flags=re.IGNORECASE))
+
+    for candidate in json_candidates:
+        try:
+            plan = _plan_from_data(json.loads(candidate.strip()))
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if plan:
+            return plan
+
+    queries: list[str] = []
+    for match in re.finditer(r"^\s*(?:\d+[.)]|[-*])\s+(.+?)\s*$", text, flags=re.MULTILINE):
+        query = match.group(1).strip().strip("`\"'“”‘’")
+        if query and query not in queries:
+            queries.append(query)
+
+    plan = _plan_from_data(queries)
+    if plan:
+        return plan
+    raise ValueError("The planner response did not contain a JSON plan or a numbered search list")
+
+
+def parse_report_data(output: str) -> ReportData:
+    """Parse a structured report, falling back to a provider's markdown output."""
+    text = output.strip()
+    json_candidates = [text]
+    json_candidates.extend(re.findall(r"```(?:json)?\s*([\s\S]*?)```", text, flags=re.IGNORECASE))
+    for candidate in json_candidates:
+        try:
+            return ReportData.model_validate(json.loads(candidate.strip()))
+        except (json.JSONDecodeError, TypeError, ValueError):
+            continue
+
+    if not text:
+        raise ValueError("The writer response was empty")
+
+    follow_up_questions: list[str] = []
+    follow_up_heading = re.search(
+        r"^#{1,6}\s*(?:follow[- ]?up questions|后续问题|延伸问题)\s*$",
+        text,
+        flags=re.IGNORECASE | re.MULTILINE,
+    )
+    markdown_report = text
+    if follow_up_heading:
+        markdown_report = text[: follow_up_heading.start()].rstrip()
+        follow_up_section = text[follow_up_heading.end() :]
+        follow_up_questions = [
+            match.group(1).strip()
+            for match in re.finditer(r"^\s*(?:\d+[.)]|[-*])\s+(.+?)\s*$", follow_up_section, flags=re.MULTILINE)
+        ]
+
+    paragraphs = [
+        paragraph.strip()
+        for paragraph in re.split(r"\n\s*\n", markdown_report)
+        if paragraph.strip() and not paragraph.lstrip().startswith("#")
+    ]
+    summary = paragraphs[0] if paragraphs else markdown_report
+    return ReportData(
+        short_summary=summary[:500],
+        markdown_report=markdown_report,
+        follow_up_questions=follow_up_questions,
+    )

--- a/examples/research/prompts.yaml
+++ b/examples/research/prompts.yaml
@@ -1,9 +1,15 @@
 PLANNER_PROMPT: |
-  You are a helpful research assistant. Given a query, come up with a set of web searches to perform to best answer the query. Output between 5 and 20 terms to query for.
+  You are a helpful research assistant. Given a query, come up with a set of web searches to perform to best answer the query. Output between 5 and 20 searches.
+
+  Return JSON only, using this shape:
+  {"searches": [{"reason": "why this search is useful", "query": "search terms"}]}
 
 SEARCH_PROMPT: |
   You are a research assistant. Given a search term, you search the web for that term and produce a concise summary of the results. The summary must be 2-3 paragraphs and less than 300 words. Capture the main points. Write succinctly, no need to have complete sentences or good grammar. This will be consumed by someone synthesizing a report, so its vital you capture the essence and ignore any fluff. Do not include any additional commentary other than the summary itself.
 
 WRITER_PROMPT: |
   You are a senior researcher tasked with writing a cohesive report for a research query. You will be provided with the original query, and some initial research done by a research assistant.
-  You should first come up with an outline for the report that describes the structure and flow of the report. Then, generate the report and return that as your final output. The final output should be in markdown format, and it should be lengthy and detailed. Aim for 5-10 pages of content, at least 1000 words.
+  You should first come up with an outline for the report that describes the structure and flow of the report. Then, generate a lengthy and detailed markdown report. Aim for 5-10 pages of content, at least 1000 words.
+
+  Return JSON only, using this shape:
+  {"short_summary": "2-3 sentence summary", "markdown_report": "the full markdown report", "follow_up_questions": ["a question to research next"]}

--- a/tests/test_research_example.py
+++ b/tests/test_research_example.py
@@ -1,0 +1,56 @@
+import pytest
+
+from examples.research.plan_parser import parse_report_data, parse_search_plan
+
+
+@pytest.mark.parametrize(
+    ("output", "expected_queries"),
+    [
+        (
+            '{"searches": [{"reason": "Find the release notes", "query": "Youtu-Agent releases"}]}',
+            ["Youtu-Agent releases"],
+        ),
+        (
+            """```json
+            {"searches": ["agent evaluation metrics", "LLM judge reliability"]}
+            ```""",
+            ["agent evaluation metrics", "LLM judge reliability"],
+        ),
+        (
+            '1. "马云出生日期"\n2. "Jack Ma birthday"\n- 马云个人资料',
+            ["马云出生日期", "Jack Ma birthday", "马云个人资料"],
+        ),
+    ],
+)
+def test_parse_search_plan(output: str, expected_queries: list[str]):
+    plan = parse_search_plan(output)
+
+    assert [item.query for item in plan.searches] == expected_queries
+    assert all(item.reason for item in plan.searches)
+
+
+def test_parse_search_plan_rejects_unstructured_text():
+    with pytest.raises(ValueError, match="did not contain"):
+        parse_search_plan("I cannot create a search plan.")
+
+
+def test_parse_report_data_from_json():
+    report = parse_report_data(
+        '{"short_summary": "Summary", "markdown_report": "# Report\\nDetails", '
+        '"follow_up_questions": ["What comes next?"]}'
+    )
+
+    assert report.short_summary == "Summary"
+    assert report.markdown_report == "# Report\nDetails"
+    assert report.follow_up_questions == ["What comes next?"]
+
+
+def test_parse_report_data_falls_back_to_markdown():
+    report = parse_report_data(
+        "# Research report\n\nThe evidence supports the conclusion.\n\n"
+        "## Follow-up questions\n\n- What should be validated next?"
+    )
+
+    assert report.short_summary == "The evidence supports the conclusion."
+    assert report.markdown_report == "# Research report\n\nThe evidence supports the conclusion."
+    assert report.follow_up_questions == ["What should be validated next?"]


### PR DESCRIPTION
## Summary

Make the `examples/research` workflow work with OpenAI-compatible providers that do not reliably implement native structured output, including the DeepSeek configuration reported in #165.

Previously both the planner and writer passed Pydantic types as `output_type`. A provider returning a valid numbered search list or Markdown report caused the Agents SDK to fail before the example could consume the response.

This change:

- requests provider-neutral JSON in the planner and writer prompts;
- parses raw JSON and fenced JSON responses;
- accepts numbered/bulleted planner output as a compatibility fallback;
- preserves a Markdown report when the writer does not return JSON, while extracting a summary and follow-up questions;
- caps normalized search plans at 20 entries and supplies missing reasons;
- moves the pure parsing logic into a testable module.

Fixes #165

## Testing

- `python -m pytest -q tests/test_research_example.py` — 6 passed
- `ruff check examples/research/main.py examples/research/plan_parser.py tests/test_research_example.py`
- `ruff format --check examples/research/main.py examples/research/plan_parser.py tests/test_research_example.py`
- `python -m py_compile examples/research/main.py examples/research/plan_parser.py tests/test_research_example.py`

Tests cover structured JSON, fenced JSON, the numbered Chinese output from the issue, invalid planner output, structured report JSON, and Markdown report fallback.
