### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,33 @@
+name: Trustabl Agent Scanner
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# Minimal top-level permissions; write grants are scoped to the scan job only.
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: trustabl-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      security-events: write
+      pull-requests: write
+    # continue-on-error keeps this job advisory — findings are reported but
+    # CI does not go red so unrelated work is never blocked.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: trustabl/trustabl-action@973f666d20b5fbb2e6a4511bd3846e965a08c28b # v0.4.1
+        with:
+          version: v0.1.6


### PR DESCRIPTION
We came across your repo and we like that you're building an agent framework for data analysis, file processing, and deep research with open-source models. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [HIGH] Network call has no timeout
   File: examples/mcp/sse_example/server.py
   What it means: An MCP tool handler that makes a network request without a timeout can hang indefinitely on a slow or unresponsive host.

2. [HIGH] Tool fetches a caller-controlled URL (SSRF)
   File: examples/mcp/sse_example/server.py
   What it means: This MCP tool issues an HTTP request to a URL built from a parameter or an interpolated string rather than a fixed literal.

3. [HIGH] Network call has no timeout
   File: examples/mcp/streamablehttp_example/server.py
   What it means: An MCP tool handler that makes a network request without a timeout can hang indefinitely on a slow or unresponsive host.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)